### PR TITLE
Add Jest unit tests for user use cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/src/user/application/use-cases/login-user.use-case.spec.ts
+++ b/src/user/application/use-cases/login-user.use-case.spec.ts
@@ -1,0 +1,62 @@
+import { LoginUserUseCase } from './login-user.use-case';
+import { IUserRepository } from '../../domain/interfaces/repositories/user-repository.interface';
+import { JwtService } from '@nestjs/jwt';
+import { User } from '../../domain/entities/user.entity';
+import { randomUUID } from 'crypto';
+import * as bcrypt from 'bcrypt';
+
+jest.mock('bcrypt');
+
+describe('LoginUserUseCase', () => {
+  let useCase: LoginUserUseCase;
+  let userRepository: jest.Mocked<IUserRepository>;
+  let jwtService: jest.Mocked<JwtService>;
+
+  beforeEach(() => {
+    userRepository = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findAll: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<IUserRepository>;
+
+    jwtService = {
+      sign: jest.fn(),
+    } as unknown as jest.Mocked<JwtService>;
+
+    useCase = new LoginUserUseCase(userRepository, jwtService);
+  });
+
+  it('should login a user and return a token', async () => {
+    const user = new User(
+      randomUUID() as any,
+      'John',
+      'john@example.com',
+      'hashedPassword',
+      '123456',
+      new Date(),
+      new Date(),
+    );
+
+    userRepository.findByEmail.mockResolvedValue(user);
+    jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+    jwtService.sign.mockReturnValue('token');
+
+    const result = await useCase.execute('john@example.com', 'plain');
+
+    expect(bcrypt.compare).toHaveBeenCalledWith('plain', 'hashedPassword');
+    expect(jwtService.sign).toHaveBeenCalledWith({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+    });
+    expect(result).toEqual({ token: 'token' });
+  });
+
+  it('should throw when credentials are invalid', async () => {
+    userRepository.findByEmail.mockResolvedValue(null);
+    await expect(useCase.execute('no@mail.com', '123')).rejects.toThrow('Credenciais inválidas');
+  });
+});

--- a/src/user/application/use-cases/register-user.use-case.spec.ts
+++ b/src/user/application/use-cases/register-user.use-case.spec.ts
@@ -1,0 +1,51 @@
+import { RegisterUserUseCase } from './register-user.use-case';
+import { IUserRepository } from '../../domain/interfaces/repositories/user-repository.interface';
+import { User } from '../../domain/entities/user.entity';
+import * as bcrypt from 'bcrypt';
+import { randomUUID } from 'crypto';
+
+jest.mock('bcrypt');
+
+describe('RegisterUserUseCase', () => {
+  let useCase: RegisterUserUseCase;
+  let userRepository: jest.Mocked<IUserRepository>;
+
+  beforeEach(() => {
+    userRepository = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findAll: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<IUserRepository>;
+
+    useCase = new RegisterUserUseCase(userRepository);
+  });
+
+  it('should register a new user', async () => {
+    userRepository.findByEmail.mockResolvedValue(null);
+    jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed' as never);
+
+    const input = {
+      name: 'John',
+      email: 'john@example.com',
+      password: '123456',
+      phone: '123',
+    };
+
+    const result = await useCase.execute(input);
+
+    expect(bcrypt.hash).toHaveBeenCalledWith('123456', 5);
+    expect(userRepository.create).toHaveBeenCalled();
+    expect(result).toHaveProperty('id');
+  });
+
+  it('should throw if email already exists', async () => {
+    userRepository.findByEmail.mockResolvedValue({} as User);
+
+    await expect(
+      useCase.execute({ name: '', email: 'test', password: '', phone: '' }),
+    ).rejects.toThrow('Usuário com este email já existe');
+  });
+});

--- a/src/user/application/use-cases/user-use-case.spec.ts
+++ b/src/user/application/use-cases/user-use-case.spec.ts
@@ -1,0 +1,34 @@
+import { UserUseCase } from './user-use-case';
+import { IUserRepository } from '../../domain/interfaces/repositories/user-repository.interface';
+import { User } from '../../domain/entities/user.entity';
+import { randomUUID } from 'crypto';
+
+describe('UserUseCase', () => {
+  let useCase: UserUseCase;
+  let userRepository: jest.Mocked<IUserRepository>;
+
+  beforeEach(() => {
+    userRepository = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findAll: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<IUserRepository>;
+
+    useCase = new UserUseCase(userRepository);
+  });
+
+  it('should return all users', async () => {
+    const users = [
+      new User(randomUUID() as any, 'John', 'john@example.com', 'pwd', '123', new Date(), new Date()),
+    ];
+    userRepository.findAll.mockResolvedValue(users);
+
+    const result = await useCase.findAll();
+
+    expect(result).toEqual(users);
+    expect(userRepository.findAll).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest path mapping
- add unit tests for login, register and list users use cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f8551b910832e9b822be25ed72325